### PR TITLE
Show a toast if there is no notification

### DIFF
--- a/app/src/main/java/com/tengu/sharetoclipboard/ShareToClipboardActivity.java
+++ b/app/src/main/java/com/tengu/sharetoclipboard/ShareToClipboardActivity.java
@@ -184,6 +184,8 @@ public class ShareToClipboardActivity extends Activity {
 
         if (PreferenceUtil.shouldDisplayNotification(this)) {
             NotificationUtil.createNotification(this);
+        } else {
+            showToast(getString(R.string.notification_title));
         }
     }
 }


### PR DESCRIPTION
This ensures that there is always visual feedback when using share to
clipboard. Fixes #33.